### PR TITLE
Add page url to the payload of "register" message

### DIFF
--- a/src/content-script-tools/text-syncer.js
+++ b/src/content-script-tools/text-syncer.js
@@ -1,9 +1,9 @@
 const NORMAL_CLOSE_CODE = 1000;
 
 class TextSyncer {
-  linkElem(title, handler, options) {
+  linkElem(url, title, handler, options) {
     const port = chrome.runtime.connect();
-    this.register(port, title, handler, options);
+    this.register(port, url, title, handler, options);
     port.onMessage.addListener(this.makeMessageListener(handler));
     const textChangeListener = this.makeTextChangeListener(port, handler);
     handler.bindChange(textChangeListener, false);
@@ -40,10 +40,10 @@ class TextSyncer {
     };
   }
 
-  register(port, title, handler, options) {
+  register(port, url, title, handler, options) {
     options = options || {};
     handler.getValue().then((text) => {
-      const payload = {title: title, text: text};
+      const payload = {url: url, title: title, text: text};
       let extension = options.extension;
       if (extension) {
         if (extension[0] !== '.') {

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -2,6 +2,7 @@ import {handlerFactory} from './handlers';
 import {textSyncer, contentEvents, elementNormalizer} from './content-script-tools';
 
 function run() {
+  const url = document.URL;
   const title = document.title;
   const activeElement = elementNormalizer.normalize(document.activeElement);
 
@@ -16,7 +17,7 @@ function run() {
   const handler = new Handler(activeElement, contentEvents);
 
   handler.load().then((options) => {
-    textSyncer.linkElem(title, handler, options);
+    textSyncer.linkElem(url, title, handler, options);
   });
 }
 


### PR DESCRIPTION
Hi @tuvistavie,

I'm the author of [Atomic Chrome for Emacs](https://github.com/alpha22jp/atomic-chrome). It's an Emacs clone of Atomic Chrome which allows you to use Emacs as a editor of Atomic Chrome instead of Atom.

Some users want to automatically select editing mode depending on website (e.g. markdown mode for GitHub pages) like [Edit with Emacs](https://github.com/stsquad/emacs_chrome) can do. It requires that the Chrome extension sends the page URL to the editor. Could you consider merging this patch to do that?
